### PR TITLE
fix: update link order to the intended sequence

### DIFF
--- a/sections/Hero.tsx
+++ b/sections/Hero.tsx
@@ -20,8 +20,8 @@ export default function Hero({
     headline = "The digital experience platform that combines performance and personalization for the ultimate sales results.",
     links = [
         { title: "Official website", "href": "https://deco.cx/", },
-        { title: "Linkedin", "href": "https://deco.cx/discord", },
-        { title: "Discord", "href": "https://www.linkedin.com/company/deco-cx/", },
+        { title: "Linkedin", "href": "https://www.linkedin.com/company/deco-cx/", },
+        { title: "Discord", "href": "https://deco.cx/discord", },
     ]
 }: Props) {
     return (


### PR DESCRIPTION
## Description

This pull request addresses the issue where the Linkedin and Discord links were switched in the links list. The order has been corrected to match the intended arrangement, ensuring the links now point to their respective destinations correctly.