### PR TITLE
chore: use https://deco.cx/run

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "imports": {
     "site/": "./",
-    "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.80.2/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.53.1/",
+    "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.81.2/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.53.5/",
     "$fresh/": "https://deno.land/x/fresh@1.6.8/",
     "preact": "https://esm.sh/preact@10.19.6",
     "preact/": "https://esm.sh/preact@10.19.6/",
@@ -11,10 +11,10 @@
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.5.1",
     "std/": "https://deno.land/std@0.190.0/",
     "daisyui": "npm:daisyui@4.4.19",
-    "@deco/htmx": "https://denopkg.com/deco-cx/apps@0.53.1/htmx/mod.ts"
+    "@deco/htmx": "https://denopkg.com/deco-cx/apps@0.53.5/htmx/mod.ts"
   },
   "tasks": {
-    "start": "deno task bundle && deno run -A --env --config=deno.json $(deno eval 'console.log(import.meta.resolve(\"deco/hypervisor/main.ts\"))') --build-cmd 'deno task build' -- deno task dev",
+    "start": "deno task bundle && deno run -A --unstable-http --env --config=deno.json https://deco.cx/run --build-cmd 'deno task build' -- deno task dev",
     "gen": "deno run -A dev.ts --gen-only",
     "play": "USE_LOCAL_STORAGE_ONLY=true deno task start",
     "component": "deno eval 'import \"deco/scripts/component.ts\"'",


### PR DESCRIPTION
Upgrades task start to use https://deco.cx/run instead of arcane eval. Basically, replaces:
`$(deno eval 'console.log(import.meta.resolve(\"deco/hypervisor/main.ts\"))')` with `https://deco.cx/run`